### PR TITLE
Output death_dt to csv file

### DIFF
--- a/src/plan.R
+++ b/src/plan.R
@@ -4,6 +4,7 @@ plan <- drake_plan(
     fhm_files = target(list_fhm_files(folder = file_in(!!file.path("data", "FHM"))), format = "file"),
     death_dts = target(load_fhm(fhm_files), dynamic = map(fhm_files)),
     death_dt = join_data(death_dts),
+    write.csv(death_dt, file_out(!!file.path("data", "FHM", "covid_deaths_latest.csv"))),
     death_prediction = predict_lag(death_dt),
 
     # Plots


### PR DESCRIPTION
It would be useful for other projects to have access to your cleaned up data without setting up an R environment. This change would make `covid_deaths_latest.csv` available directly on github.

Perhaps additional changes are needed in your github workflow to push a new version automatically every day?