### PR TITLE
Use cache@v2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
                   r-version: "4.0.0"
 
             - name: renv cache
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               with:
                   path: ~/.local/share/renv
                   key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}


### PR DESCRIPTION
The [recently released v2](https://github.com/actions/cache/releases/tag/v2.0.0) of github cache action will use caching for scheduled actions. This should speed up the daily updates significantly. Should probably go from 10-15 minutes to 2-3 minutes.